### PR TITLE
Add DebugPrint extension method

### DIFF
--- a/Bumblebee/Extensions/Debugging.cs
+++ b/Bumblebee/Extensions/Debugging.cs
@@ -30,6 +30,12 @@ namespace Bumblebee.Extensions
             return obj;
         }
 
+        public static T DebugBreak<T>(this T obj)
+        {
+            System.Diagnostics.Debugger.Break();
+            return obj;
+        }
+
         public static T PlaySound<T>(this T obj, int pause = 0)
         {
             System.Media.SystemSounds.Exclamation.Play();


### PR DESCRIPTION
We already have inline stores and verifies -- this acts an inline breakpoint.  Could save us from assigning half a test run to a variable for debugging.
