### PR TITLE
Rename BlockEnumerable and ElementEnumerable

### DIFF
--- a/src/Bumblebee.IntegrationTests/Bumblebee.IntegrationTests.csproj
+++ b/src/Bumblebee.IntegrationTests/Bumblebee.IntegrationTests.csproj
@@ -82,8 +82,8 @@
     <Compile Include="Implementation\IEnumerableOfBlocksTests.cs" />
     <Compile Include="Implementation\InlineFrameTests\Given_nested_inline_frames.cs" />
     <Compile Include="Implementation\PageTests.cs" />
-    <Compile Include="Implementation\WebPageTests\given_web_page_with_explicit_wait.cs" />
-    <Compile Include="Implementation\WebPageTests\given_web_page_with_no_wait.cs" />
+    <Compile Include="Implementation\WebPageTests\Given_web_page_with_explicit_wait.cs" />
+    <Compile Include="Implementation\WebPageTests\Given_web_page_with_no_wait.cs" />
     <Compile Include="Setup\SessionTests\Given_user_has_navigated_to_a_page.cs" />
     <Compile Include="Setup\ThreadedSessionTests\Given_user_has_navigated_to_a_page.cs" />
     <Compile Include="Shared\Pages\DefaultPage.cs" />

--- a/src/Bumblebee.IntegrationTests/CallStackTests.cs
+++ b/src/Bumblebee.IntegrationTests/CallStackTests.cs
@@ -5,10 +5,12 @@ using FluentAssertions;
 
 using NUnit.Framework;
 
+// ReSharper disable InconsistentNaming
+
 namespace Bumblebee.IntegrationTests
 {
 	[TestFixture]
-    public class Given_call_stack
+	public class Given_call_stack
 	{
 		[Test]
 		public void When_GetCurrentMethod_is_called_Then_current_method_is_returned()
@@ -97,44 +99,42 @@ namespace Bumblebee.IntegrationTests
 		}
 	}
 
-    // ReSharper disable InconsistentNaming
+	public class CallsGetConstructingMethodInConstructor
+	{
+		public MethodBase ConstructingMethod { get; private set; }
 
-    public class CallsGetConstructingMethodInConstructor
-    {
-        public MethodBase ConstructingMethod { get; private set; }
+		public CallsGetConstructingMethodInConstructor()
+		{
+			ConstructingMethod = CallStack.GetConstructingMethod();
+		}
+	}
 
-        public CallsGetConstructingMethodInConstructor()
-        {
-            ConstructingMethod = CallStack.GetConstructingMethod();
-        }
-    }
+	public class InheritsFromCallsGetConstructingMethodInConstructor : CallsGetConstructingMethodInConstructor
+	{
+	}
 
-    public class InheritsFromCallsGetConstructingMethodInConstructor : CallsGetConstructingMethodInConstructor
-    {
-    }
+	[Bumblebee]
+	public static class InvisibleClass
+	{
+		public static MethodBase InvisibleMethod()
+		{
+			return CallStack.GetFirstNonBumblebeeMethod();
+		}
+	}
 
-    [Bumblebee]
-    public static class InvisibleClass
-    {
-        public static MethodBase InvisibleMethod()
-        {
-            return CallStack.GetFirstNonBumblebeeMethod();
-        }
-    }
+	public static class GenericClass<T>
+	{
+		public static Tuple<MethodBase, MethodBase> GetMethodBase()
+		{
+			return new Tuple<MethodBase, MethodBase>(MethodBase.GetCurrentMethod(), CallStack.GetFirstNonBumblebeeMethod());
+		}
+	}
 
-    public static class GenericClass<T>
-    {
-        public static Tuple<MethodBase, MethodBase> GetMethodBase()
-        {
-            return new Tuple<MethodBase, MethodBase>(MethodBase.GetCurrentMethod(), CallStack.GetFirstNonBumblebeeMethod());
-        }
-    }
-
-    public static class NonGenericClass
-    {
-        public static Tuple<MethodBase, MethodBase> GenericMethod<T>()
-        {
-            return new Tuple<MethodBase, MethodBase>(MethodBase.GetCurrentMethod(), CallStack.GetFirstNonBumblebeeMethod());
-        }
-    }
+	public static class NonGenericClass
+	{
+		public static Tuple<MethodBase, MethodBase> GenericMethod<T>()
+		{
+			return new Tuple<MethodBase, MethodBase>(MethodBase.GetCurrentMethod(), CallStack.GetFirstNonBumblebeeMethod());
+		}
+	}
 }

--- a/src/Bumblebee.IntegrationTests/Content/SlowWebPage.html
+++ b/src/Bumblebee.IntegrationTests/Content/SlowWebPage.html
@@ -8,7 +8,7 @@
 			function init() {
 				setTimeout(function () {
 					var body = document.getElementsByTagName("body")[0];
-					body.innerHTML = '<input id="firstName" type="textbox"/>';
+					body.innerHTML = '<input id="firstName" type="textbox" />';
 					var firstName = document.getElementById('firstName');
 					firstName.value = 'Todd';
 				}, 5000);
@@ -16,6 +16,5 @@
 		</script>
 	</head>
 	<body onload="init()">
-		
 	</body>
 </html>

--- a/src/Bumblebee.IntegrationTests/Implementation/PageTests.cs
+++ b/src/Bumblebee.IntegrationTests/Implementation/PageTests.cs
@@ -11,76 +11,76 @@ using FluentAssertions;
 
 using NUnit.Framework;
 
-using OpenQA.Selenium;
+// ReSharper disable InconsistentNaming
 
 namespace Bumblebee.IntegrationTests.Implementation
 {
-    [TestFixture]
-    public class given_session_when_constructing : HostTestFixture
-    {
-		private readonly ThreadLocal<Session> _session = new ThreadLocal<Session>(() => new Session(new PhantomJS())); 
+	[TestFixture]
+	public class Given_session_when_constructing : HostTestFixture
+	{
+		private readonly ThreadLocal<Session> _session = new ThreadLocal<Session>(() => new Session(new PhantomJS()));
 
 		[TestFixtureSetUp]
-        public void TestFixtureSetUp()
-        {
-	        Session
+		public void TestFixtureSetUp()
+		{
+			Session
 				.NavigateTo<TestablePage>(GetUrl("Dialogs.html"));
-        }
+		}
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
-        {
+		[TestFixtureTearDown]
+		public void TestFixtureTearDown()
+		{
 			Session
-                .End();
-        }
+				.End();
+		}
 
-        [Test]
-        public void should_load_body_as_tag()
-        {
+		[Test]
+		public void Should_load_body_as_tag()
+		{
 			Session
-                .CurrentBlock<TestablePage>()
-                .Tag
-                .VerifyThat(t => t.TagName.Should().Be("body"));
-        }
+				.CurrentBlock<TestablePage>()
+				.Tag
+				.VerifyThat(t => t.TagName.Should().Be("body"));
+		}
 
-        [Test]
-        public void should_leave_parent_null()
-        {
+		[Test]
+		public void should_leave_parent_null()
+		{
 			Session
-                .CurrentBlock<TestablePage>()
-                .VerifyThat(p => p.Parent.Should().BeNull());
-        }
+				.CurrentBlock<TestablePage>()
+				.VerifyThat(p => p.Parent.Should().BeNull());
+		}
 
-	    [Test]
-	    public void should_return_same_session()
-	    {
+		[Test]
+		public void should_return_same_session()
+		{
 			Session
-			    .CurrentBlock<TestablePage>()
+				.CurrentBlock<TestablePage>()
 				.VerifyThat(p => p.Session.Should().Be(Session));
-	    }
-		
-	    public Session Session
-	    {
-		    get { return _session.Value; }
-	    }
-    }
+		}
 
-    [TestFixture]
-    public class PageTests
-    {
-        [Test]
-        public void given_null_session_when_constructing_page_should_throw()
-        {
-            Action action = () => new TestablePage(null);
-            action.ShouldThrow<ArgumentNullException>()
-                .WithMessage("Value cannot be null.\r\nParameter name: session");
-        }
-    }
+		public Session Session
+		{
+			get { return _session.Value; }
+		}
+	}
 
-    public class TestablePage : Page
-    {
-        public TestablePage(Session session) : base(session)
-        {
-        }
-    }
+	[TestFixture]
+	public class PageTests
+	{
+		[Test]
+		public void Given_null_session_when_constructing_page_should_throw()
+		{
+			Action action = () => new TestablePage(null);
+			action.ShouldThrow<ArgumentNullException>()
+				.WithMessage("Value cannot be null.\r\nParameter name: session");
+		}
+	}
+
+	public class TestablePage : Page
+	{
+		public TestablePage(Session session) : base(session)
+		{
+		}
+	}
 }

--- a/src/Bumblebee.IntegrationTests/Implementation/WebPageTests/given_web_page_with_explicit_wait.cs
+++ b/src/Bumblebee.IntegrationTests/Implementation/WebPageTests/given_web_page_with_explicit_wait.cs
@@ -9,10 +9,12 @@ using FluentAssertions;
 
 using NUnit.Framework;
 
-namespace Bumblebee.IntegrationTests.Implementation
+// ReSharper disable InconsistentNaming
+
+namespace Bumblebee.IntegrationTests.Implementation.WebPageTests
 {
 	[TestFixture]
-	public class given_web_page_with_explicit_wait : HostTestFixture
+	public class Given_web_page_with_explicit_wait : HostTestFixture
 	{
 		[SetUp]
 		public void TestSetUp()
@@ -31,7 +33,7 @@ namespace Bumblebee.IntegrationTests.Implementation
 		}
 
 		[Test]
-		public void given_slow_load_when_getting_an_element_using_wait_should_wait()
+		public void Given_slow_load_when_getting_an_element_using_wait_Should_wait()
 		{
 			Threaded<Session>
 				.CurrentBlock<SlowWebPageWithExplicitWait>()

--- a/src/Bumblebee.IntegrationTests/Implementation/WebPageTests/given_web_page_with_no_wait.cs
+++ b/src/Bumblebee.IntegrationTests/Implementation/WebPageTests/given_web_page_with_no_wait.cs
@@ -11,10 +11,12 @@ using NUnit.Framework;
 
 using OpenQA.Selenium;
 
-namespace Bumblebee.IntegrationTests.Implementation
+// ReSharper disable InconsistentNaming
+
+namespace Bumblebee.IntegrationTests.Implementation.WebPageTests
 {
 	[TestFixture]
-	public class given_web_page_with_no_wait : HostTestFixture
+	public class Given_web_page_with_no_wait : HostTestFixture
 	{
 		[SetUp]
 		public void TestSetUp()
@@ -33,7 +35,7 @@ namespace Bumblebee.IntegrationTests.Implementation
 		}
 
 		[Test]
-		public void given_slow_load_when_getting_an_element_using_wait_should_throw()
+		public void Given_slow_load_when_getting_an_element_using_wait_Should_throw()
 		{
 			Action action = () =>
 				Threaded<Session>

--- a/src/Bumblebee.IntegrationTests/KeyTests.cs
+++ b/src/Bumblebee.IntegrationTests/KeyTests.cs
@@ -13,7 +13,8 @@ namespace Bumblebee.IntegrationTests
 	// ReSharper disable InconsistentNaming
 
 	[TestFixture(typeof (Chrome))]
-	public class Given_keys<T> : HostTestFixture where T : IDriverEnvironment, new()
+	public class Given_keys<T> : HostTestFixture
+		where T : IDriverEnvironment, new()
 	{
 		private static readonly Key[] Data =
 		{

--- a/src/Bumblebee.IntegrationTests/Setup/SessionTests/Given_environment_and_default_settings_When_capturing_from_generic_method.cs
+++ b/src/Bumblebee.IntegrationTests/Setup/SessionTests/Given_environment_and_default_settings_When_capturing_from_generic_method.cs
@@ -11,38 +11,40 @@ using FluentAssertions;
 
 using NUnit.Framework;
 
+// ReSharper disable InconsistentNaming
+
 namespace Bumblebee.IntegrationTests.Setup.SessionTests
 {
-    [TestFixture]
+	[TestFixture]
 
-    public class Given_environment_and_default_settings_When_capturing_from_generic_method : HostTestFixture
-    {
-        [Test]
-        public void should_save_in_executing_directory()
-        {
-            var environment = new InternetExplorer();
-            var session = new Session(environment);
-            session.NavigateTo<CheckboxPage>(GetUrl("Checkbox.html"));
+	public class Given_environment_and_default_settings_When_capturing_from_generic_method : HostTestFixture
+	{
+		[Test]
+		public void Should_save_in_executing_directory()
+		{
+			var environment = new InternetExplorer();
+			var session = new Session(environment);
+			session.NavigateTo<CheckboxPage>(GetUrl("Checkbox.html"));
 
-            var path = GenericMethod(session);
+			var path = GenericMethod(session);
 
-            File.Exists(path).Should().BeTrue();
+			File.Exists(path).Should().BeTrue();
 
-            session.End();
-            File.Delete(path);
-        }
+			session.End();
+			File.Delete(path);
+		}
 
-        private string GenericMethod<T>(T session) where T:Session
-        {
-            var currentMethod = String.Format("{0}.png", CallStack.GetCurrentMethod().GetFullName());
-            var defaultSettings = new Settings();
+		private string GenericMethod<T>(T session) where T : Session
+		{
+			var currentMethod = String.Format("{0}.png", CallStack.GetCurrentMethod().GetFullName());
+			var defaultSettings = new Settings();
 
-            var path = Path.Combine(defaultSettings.ScreenCapturePath, currentMethod);
-            File.Delete(path);
+			var path = Path.Combine(defaultSettings.ScreenCapturePath, currentMethod);
+			File.Delete(path);
 
-            session.CaptureScreen();
+			session.CaptureScreen();
 
-            return path;
-        }
-    }
+			return path;
+		}
+	}
 }

--- a/src/Bumblebee.IntegrationTests/Setup/SessionTests/SessionTests.cs
+++ b/src/Bumblebee.IntegrationTests/Setup/SessionTests/SessionTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Bumblebee.Extensions;
+﻿using Bumblebee.Extensions;
 using Bumblebee.IntegrationTests.Shared.Hosting;
 using Bumblebee.IntegrationTests.Shared.Pages;
 using Bumblebee.Setup;

--- a/src/Bumblebee.IntegrationTests/Setup/SessionTests/given_environment_and_default_settings_when_capturing.cs
+++ b/src/Bumblebee.IntegrationTests/Setup/SessionTests/given_environment_and_default_settings_when_capturing.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 
 namespace Bumblebee.IntegrationTests.Setup.SessionTests
 {
-    [TestFixture]
+	[TestFixture]
 	public class Given_environment_and_default_settings_When_capturing : HostTestFixture
 	{
 		private string path;

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/CheckboxPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/CheckboxPage.cs
@@ -2,8 +2,6 @@
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class CheckboxPage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/ComplexTablePage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/ComplexTablePage.cs
@@ -4,8 +4,6 @@ using Bumblebee.Implementation;
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class ComplexTablePage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/DateFieldPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/DateFieldPage.cs
@@ -2,8 +2,6 @@
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class DateFieldPage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/DialogPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/DialogPage.cs
@@ -2,8 +2,6 @@
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class DialogPage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/DoubleClickablePage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/DoubleClickablePage.cs
@@ -4,8 +4,6 @@ using Bumblebee.Implementation;
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class DoubleClickablePage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/GenericTablePage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/GenericTablePage.cs
@@ -4,8 +4,6 @@ using Bumblebee.Implementation;
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class GenericTablePage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/KeysPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/KeysPage.cs
@@ -2,8 +2,6 @@
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class KeysPage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/ListOfComplexBlocksPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/ListOfComplexBlocksPage.cs
@@ -38,7 +38,7 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 
 		public IEnumerable<ComplexBlock> Items
 		{
-			get { return new BlockEnumerable<ComplexBlock>(this, By.CssSelector("li")); }
+			get { return new Blocks<ComplexBlock>(this, By.CssSelector("li")); }
 		}
 	}
 

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/MultiSelectPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/MultiSelectPage.cs
@@ -2,8 +2,6 @@
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class MultiSelectPage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/NumericFieldPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/NumericFieldPage.cs
@@ -2,8 +2,6 @@
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class NumericFieldPage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/RadioButtonsPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/RadioButtonsPage.cs
@@ -4,8 +4,6 @@ using Bumblebee.Implementation;
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class RadioButtonsPage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/SlowWebPageWithExplicitWait.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/SlowWebPageWithExplicitWait.cs
@@ -4,8 +4,6 @@ using Bumblebee.Implementation;
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class SlowWebPageWithExplicitWait : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/SlowWebPageWithNoWait.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/SlowWebPageWithNoWait.cs
@@ -15,8 +15,7 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 
 		public ITextField FirstName
 		{
-			get {  return Wait.Until(x => new TextField(this, By.Id("firstName")));}
+			get { return Wait.Until(x => new TextField(this, By.Id("firstName")));}
 		}
-		
 	}
 }

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/SlowWebPageWithNoWait.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/SlowWebPageWithNoWait.cs
@@ -4,8 +4,6 @@ using Bumblebee.Implementation;
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class SlowWebPageWithNoWait : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/TablePage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/TablePage.cs
@@ -4,8 +4,6 @@ using Bumblebee.Implementation;
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class TablePage : WebPage

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/TextFieldPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/TextFieldPage.cs
@@ -2,8 +2,6 @@
 using Bumblebee.Interfaces;
 using Bumblebee.Setup;
 
-using OpenQA.Selenium;
-
 namespace Bumblebee.IntegrationTests.Shared.Pages
 {
 	public class TextFieldPage : WebPage

--- a/src/Bumblebee/Bumblebee.csproj
+++ b/src/Bumblebee/Bumblebee.csproj
@@ -49,7 +49,7 @@
     <Compile Include="Extensions\WebElementConvenience.cs" />
     <Compile Include="Factory.cs" />
     <Compile Include="Implementation\Blocks.cs" />
-    <Compile Include="Implementation\ElementEnumerable.cs" />
+    <Compile Include="Implementation\Elements.cs" />
     <Compile Include="Implementation\InlineFrame.cs" />
     <Compile Include="Implementation\Monkey.cs" />
     <Compile Include="Implementation\DateField.cs" />

--- a/src/Bumblebee/Bumblebee.csproj
+++ b/src/Bumblebee/Bumblebee.csproj
@@ -48,7 +48,7 @@
     <Compile Include="Extensions\Verification.cs" />
     <Compile Include="Extensions\WebElementConvenience.cs" />
     <Compile Include="Factory.cs" />
-    <Compile Include="Implementation\BlockEnumerable.cs" />
+    <Compile Include="Implementation\Blocks.cs" />
     <Compile Include="Implementation\ElementEnumerable.cs" />
     <Compile Include="Implementation\InlineFrame.cs" />
     <Compile Include="Implementation\Monkey.cs" />

--- a/src/Bumblebee/Extensions/BlockConvenience.cs
+++ b/src/Bumblebee/Extensions/BlockConvenience.cs
@@ -2,8 +2,6 @@
 
 using Bumblebee.Interfaces;
 
-using OpenQA.Selenium.Safari.Internal;
-
 namespace Bumblebee.Extensions
 {
 	public static class BlockConvenience

--- a/src/Bumblebee/Extensions/BlockConvenience.cs
+++ b/src/Bumblebee/Extensions/BlockConvenience.cs
@@ -8,8 +8,7 @@ namespace Bumblebee.Extensions
 	{
 		// TODO:  Should this be marked as error now?
 		[Obsolete("This method should no longer be used. Please use FindRelated<T> instead.", error: true)]
-		public static TScope ScopeTo<TScope>(this IBlock block)
-			where TScope : IBlock
+		public static TScope ScopeTo<TScope>(this IBlock block) where TScope : IBlock
 		{
 			return block.Session.CurrentBlock<TScope>();
 		}

--- a/src/Bumblebee/Extensions/DragAction.cs
+++ b/src/Bumblebee/Extensions/DragAction.cs
@@ -8,7 +8,8 @@ namespace Bumblebee.Extensions
 	/// Represents the drag action.
 	/// </summary>
 	/// <typeparam name="TParent">The type of the parent block.</typeparam>
-	public class DragAction<TParent> where TParent : IBlock
+	public class DragAction<TParent>
+		where TParent : IBlock
 	{
 		private TParent Parent { get; set; }
 		private IDraggable Draggable { get; set; }

--- a/src/Bumblebee/Extensions/JavaScriptExecution.cs
+++ b/src/Bumblebee/Extensions/JavaScriptExecution.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 
 using OpenQA.Selenium;
-using OpenQA.Selenium.Safari.Internal;
 using OpenQA.Selenium.Support.Extensions;
 
 namespace Bumblebee.Extensions

--- a/src/Bumblebee/Factory.cs
+++ b/src/Bumblebee/Factory.cs
@@ -10,7 +10,7 @@ namespace Bumblebee
 	internal static class Factory
 	{
 		// TODO:  Need to modify this and its uses to only work for pages.
-		public static T CreateBlockFromSession<T>(Session session) where T : IBlock // TODO: should probably create a page abstraction and use it here...
+		public static T CreateBlockFromSession<T>(Session session) where T : IBlock
 		{
 			if (session == null)
 			{

--- a/src/Bumblebee/Implementation/Block.cs
+++ b/src/Bumblebee/Implementation/Block.cs
@@ -92,6 +92,11 @@ namespace Bumblebee.Implementation
 			return null;
 		}
 
+		protected virtual IEnumerable<T> FindBlocks<T>(By @by) where T : IBlock
+		{
+			return new Blocks<T>(this, @by);
+		}
+
 		public virtual IPerformsDragAndDrop GetDragAndDropPerformer()
 		{
 			return new WebDragAndDropPerformer(Session.Driver);

--- a/src/Bumblebee/Implementation/Block.cs
+++ b/src/Bumblebee/Implementation/Block.cs
@@ -97,6 +97,11 @@ namespace Bumblebee.Implementation
 			return new Blocks<T>(this, @by);
 		}
 
+		protected virtual IEnumerable<T> FindElements<T>(By @by) where T : IElement
+		{
+			return new Elements<T>(this, @by);
+		}
+
 		public virtual IPerformsDragAndDrop GetDragAndDropPerformer()
 		{
 			return new WebDragAndDropPerformer(Session.Driver);

--- a/src/Bumblebee/Implementation/Blocks.cs
+++ b/src/Bumblebee/Implementation/Blocks.cs
@@ -9,13 +9,13 @@ using OpenQA.Selenium;
 
 namespace Bumblebee.Implementation
 {
-	public class BlockEnumerable<T> : IEnumerable<T>
+	public class Blocks<T> : IEnumerable<T>
 		where T : IBlock
 	{
 		private readonly IBlock _parent;
 		private readonly By _by;
 
-		public BlockEnumerable(IBlock parent, By @by)
+		public Blocks(IBlock parent, By @by)
 		{
 			_parent = parent;
 			_by = @by;

--- a/src/Bumblebee/Implementation/Checkbox.cs
+++ b/src/Bumblebee/Implementation/Checkbox.cs
@@ -43,7 +43,8 @@ namespace Bumblebee.Implementation
 		}
 	}
 
-	public class Checkbox<TResult> : Checkbox, ICheckbox<TResult> where TResult : IBlock
+	public class Checkbox<TResult> : Checkbox, ICheckbox<TResult>
+		where TResult : IBlock
 	{
 		public Checkbox(IBlock parent, By @by) : base(parent, @by)
 		{

--- a/src/Bumblebee/Implementation/Elements.cs
+++ b/src/Bumblebee/Implementation/Elements.cs
@@ -8,13 +8,13 @@ using OpenQA.Selenium;
 
 namespace Bumblebee.Implementation
 {
-	public class ElementEnumerable<T> : IEnumerable<T>
+	public class Elements<T> : IEnumerable<T>
 		where T : IElement
 	{
 		private readonly IBlock _parent;
 		private readonly By _by;
 
-		public ElementEnumerable(IBlock parent, By @by)
+		public Elements(IBlock parent, By @by)
 		{
 			_parent = parent;
 			_by = @by;

--- a/src/Bumblebee/Implementation/NumericField.cs
+++ b/src/Bumblebee/Implementation/NumericField.cs
@@ -44,7 +44,8 @@ namespace Bumblebee.Implementation
 		}
 	}
 
-	public class NumericField<TResult> : NumericField, INumericField<TResult> where TResult : IBlock
+	public class NumericField<TResult> : NumericField, INumericField<TResult>
+		where TResult : IBlock
 	{
 		public NumericField(IBlock parent, By @by) : base(parent, @by)
 		{

--- a/src/Bumblebee/Implementation/Option.cs
+++ b/src/Bumblebee/Implementation/Option.cs
@@ -25,7 +25,8 @@ namespace Bumblebee.Implementation
 		}
 	}
 
-	public class Option<TResult> : Option, IOption<TResult> where TResult : IBlock
+	public class Option<TResult> : Option, IOption<TResult>
+		where TResult : IBlock
 	{
 		public Option(IBlock parent, By by) : base(parent, @by)
 		{

--- a/src/Bumblebee/Implementation/RadioButton.cs
+++ b/src/Bumblebee/Implementation/RadioButton.cs
@@ -7,7 +7,8 @@ using OpenQA.Selenium;
 
 namespace Bumblebee.Implementation
 {
-	public class RadioButton<TResult> : Option<TResult> where TResult : IBlock
+	public class RadioButton<TResult> : Option<TResult>
+		where TResult : IBlock
 	{
 		public RadioButton(IBlock parent, By @by) : base(parent, @by)
 		{

--- a/src/Bumblebee/Implementation/RadioButtons.cs
+++ b/src/Bumblebee/Implementation/RadioButtons.cs
@@ -26,7 +26,7 @@ namespace Bumblebee.Implementation
 		{
 			get
 			{
-				return new ElementEnumerable<RadioButton<TResult>>(_parent, _by)
+				return new Elements<RadioButton<TResult>>(_parent, _by)
 					.Where(option => option.Tag.Displayed);
 			}
 		}

--- a/src/Bumblebee/Implementation/SelectBox.cs
+++ b/src/Bumblebee/Implementation/SelectBox.cs
@@ -14,7 +14,7 @@ namespace Bumblebee.Implementation
 
 		public virtual IEnumerable<IOption> Options
 		{
-			get { return new ElementEnumerable<Option>(this, By.TagName("option")); }
+			get { return FindElements<Option>(By.TagName("option")); }
 		}
 	}
 
@@ -27,7 +27,7 @@ namespace Bumblebee.Implementation
 
 		public virtual IEnumerable<IOption<TResult>> Options
 		{
-			get { return new ElementEnumerable<Option<TResult>>(this, By.TagName("option")); }
+			get { return FindElements<Option<TResult>>(By.TagName("option")); }
 		}
 	}
 }

--- a/src/Bumblebee/Implementation/Table.cs
+++ b/src/Bumblebee/Implementation/Table.cs
@@ -28,7 +28,7 @@ namespace Bumblebee.Implementation
 		{
 			get
 			{
-				return new BlockEnumerable<TableRow>(this, By.CssSelector("tbody > tr"));
+				return FindBlocks<TableRow>(By.CssSelector("tbody > tr"));
 			}
 		}
 
@@ -52,7 +52,7 @@ namespace Bumblebee.Implementation
 		public IEnumerable<T> RowsAs<T>()
 			where T : IBlock
 		{
-			return new BlockEnumerable<T>(this, By.CssSelector("tbody > tr"));
+			return FindBlocks<T>(By.CssSelector("tbody > tr"));
 		}
 
 		public T FooterAs<T>()

--- a/src/Bumblebee/Implementation/TextField.cs
+++ b/src/Bumblebee/Implementation/TextField.cs
@@ -42,7 +42,8 @@ namespace Bumblebee.Implementation
 		}
 	}
 
-	public class TextField<TResult> : TextField, ITextField<TResult> where TResult : IBlock
+	public class TextField<TResult> : TextField, ITextField<TResult>
+		where TResult : IBlock
 	{
 		public TextField(IBlock parent, By @by) : base(parent, @by)
 		{

--- a/src/Bumblebee/Implementation/WebBlock.cs
+++ b/src/Bumblebee/Implementation/WebBlock.cs
@@ -24,29 +24,26 @@ namespace Bumblebee.Implementation
 		{
 		}
 
-        /// <summary>
-        /// Constructor that allows for overriding the default timeout for waits.
-        /// </summary>
-        /// <param name="session">The session to be used for finding elements in the derived page.</param>
-        /// <param name="timeout">The timeout period for waits represented as a TimeSpan</param>
-        protected WebBlock(Session session, TimeSpan timeout)
-            : base(session, By.TagName("body"))
-        {
-            this.Pause(200);
-            Wait = new WebDriverWait(Session.Driver, timeout);
-        }
+		/// <summary>
+		/// Constructor that allows for overriding the default timeout for waits.
+		/// </summary>
+		/// <param name="session">The session to be used for finding elements in the derived page.</param>
+		/// <param name="timeout">The timeout period for waits represented as a TimeSpan</param>
+		protected WebBlock(Session session, TimeSpan timeout)
+			: base(session, By.TagName("body"))
+		{
+			this.Pause(200);
+			Wait = new WebDriverWait(Session.Driver, timeout);
+		}
 
-        /// <summary>
-        /// A common wait timeout that can be used when trying to find elements within derived pages or blocks.
-        /// </summary>
-        protected WebDriverWait Wait { get; private set; }
+		/// <summary>
+		/// A common wait timeout that can be used when trying to find elements within derived pages or blocks.
+		/// </summary>
+		protected WebDriverWait Wait { get; private set; }
 
-        public override IWebElement Tag
-        {
-            get
-            {
-                return Wait.Until(driver => base.Tag); // TODO: this feels....wonky
-            }
-        }
+		public override IWebElement Tag
+		{
+			get { return Wait.Until(driver => base.Tag); } // TODO: this feels....wonky
+		}
 	}
 }

--- a/src/Bumblebee/Interfaces/IPage.cs
+++ b/src/Bumblebee/Interfaces/IPage.cs
@@ -1,7 +1,6 @@
 namespace Bumblebee.Interfaces
 {
-    public interface IPage : IBlock
-    {
-        
-    }
+	public interface IPage : IBlock
+	{
+	}
 }

--- a/src/Bumblebee/JQuery/SpecifcationExtensions.cs
+++ b/src/Bumblebee/JQuery/SpecifcationExtensions.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Bumblebee.Specifications;
+﻿using Bumblebee.Specifications;
 
 using OpenQA.Selenium;
 


### PR DESCRIPTION
This pull request renames ```BlockEnumerable<T>``` to ```Blocks<T>``` and ```ElementEnumerable<T>``` to ```Elements<T>```, as well as fixing some minor styling and whitespace issues.