### PR TITLE
Modified the WebBlock to remove the constructor that accepts a Sessio…

### DIFF
--- a/src/Bumblebee/Implementation/WebBlock.cs
+++ b/src/Bumblebee/Implementation/WebBlock.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 using Bumblebee.Extensions;
-using Bumblebee.Setup;
+using Bumblebee.Interfaces;
 
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
@@ -19,18 +19,20 @@ namespace Bumblebee.Implementation
 		/// <remarks>
 		/// The default timeout for waiting for elements is 3000 ticks (3-100 nano seconds).  If you need to override this value, call the other constructor.
 		/// </remarks>
-		/// <param name="session">The session to be used for finding elements in the derived page.</param>
-		protected WebBlock(Session session) : this(session, TimeSpan.FromTicks(3000))
+		/// <param name="parent">The parent.</param>
+		/// <param name="by">The by.</param>
+		protected WebBlock(IBlock parent, By @by) : this(parent, @by, TimeSpan.FromTicks(3000))
 		{
 		}
 
 		/// <summary>
 		/// Constructor that allows for overriding the default timeout for waits.
 		/// </summary>
-		/// <param name="session">The session to be used for finding elements in the derived page.</param>
+		/// <param name="parent">The parent.</param>
+		/// <param name="by">The by.</param>
 		/// <param name="timeout">The timeout period for waits represented as a TimeSpan</param>
-		protected WebBlock(Session session, TimeSpan timeout)
-			: base(session, By.TagName("body"))
+		protected WebBlock(IBlock parent, By @by, TimeSpan timeout)
+			: base(parent, @by)
 		{
 			this.Pause(200);
 			Wait = new WebDriverWait(Session.Driver, timeout);
@@ -43,7 +45,7 @@ namespace Bumblebee.Implementation
 
 		public override IWebElement Tag
 		{
-			get { return Wait.Until(driver => base.Tag); } // TODO: this feels....wonky
+			get { return Wait.Until(driver => base.Tag); }
 		}
 	}
 }


### PR DESCRIPTION
…n, which is an artifact from the previous version that was used as a base page.  This is for base blocks that need to have a common wait driver.

This should address issue #75.