### PR TITLE
Minor cleanup and void ExecuteJavaScript function

### DIFF
--- a/src/Bumblebee.IntegrationTests/Specifications/ByJQueryTests/Given_I_am_searching_for_a_collection.cs
+++ b/src/Bumblebee.IntegrationTests/Specifications/ByJQueryTests/Given_I_am_searching_for_a_collection.cs
@@ -2,9 +2,9 @@ using System.Linq;
 
 using Bumblebee.IntegrationTests.Shared.Hosting;
 using Bumblebee.IntegrationTests.Shared.Pages;
+using Bumblebee.JQuery;
 using Bumblebee.Setup;
 using Bumblebee.Setup.DriverEnvironments;
-using Bumblebee.Specifications;
 
 using FluentAssertions;
 

--- a/src/Bumblebee.IntegrationTests/Specifications/ByJQueryTests/Given_I_am_searching_for_a_single_element.cs
+++ b/src/Bumblebee.IntegrationTests/Specifications/ByJQueryTests/Given_I_am_searching_for_a_single_element.cs
@@ -2,9 +2,9 @@ using System;
 
 using Bumblebee.IntegrationTests.Shared.Hosting;
 using Bumblebee.IntegrationTests.Shared.Pages;
+using Bumblebee.JQuery;
 using Bumblebee.Setup;
 using Bumblebee.Setup.DriverEnvironments;
-using Bumblebee.Specifications;
 
 using FluentAssertions;
 

--- a/src/Bumblebee.IntegrationTests/Specifications/ByJQueryTests/Given_an_invalid_selector.cs
+++ b/src/Bumblebee.IntegrationTests/Specifications/ByJQueryTests/Given_an_invalid_selector.cs
@@ -2,9 +2,9 @@ using System;
 
 using Bumblebee.IntegrationTests.Shared.Hosting;
 using Bumblebee.IntegrationTests.Shared.Pages;
+using Bumblebee.JQuery;
 using Bumblebee.Setup;
 using Bumblebee.Setup.DriverEnvironments;
-using Bumblebee.Specifications;
 
 using FluentAssertions;
 

--- a/src/Bumblebee/Bumblebee.csproj
+++ b/src/Bumblebee/Bumblebee.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Interfaces\IPage.cs" />
     <Compile Include="Interfaces\IPerformsDragAndDrop.cs" />
     <Compile Include="BumblebeeAttribute.cs" />
+    <Compile Include="JQuery\ByJQuery.cs" />
     <Compile Include="JQuery\SessionExtensions.cs" />
     <Compile Include="JQuery\SpecificationExtensions.cs" />
     <Compile Include="Key.cs" />
@@ -114,7 +115,6 @@
     <Compile Include="Specifications\ByExtensions.cs" />
     <Compile Include="Specifications\ByFunctionWithListOutput.cs" />
     <Compile Include="Specifications\ByFunctionWithSingleOutput.cs" />
-    <Compile Include="Specifications\ByJQuery.cs" />
     <Compile Include="Specifications\ByOrdinal.cs" />
     <Compile Include="Specifications\ByWithWait.cs" />
     <Compile Include="Specifications\ISpecification.cs" />

--- a/src/Bumblebee/JQuery/ByJQuery.cs
+++ b/src/Bumblebee/JQuery/ByJQuery.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -8,7 +8,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Internal;
 using OpenQA.Selenium.Support.Extensions;
 
-namespace Bumblebee.Specifications
+namespace Bumblebee.JQuery
 {
 	internal class ByJQuery : By
 	{

--- a/src/Bumblebee/Setup/Session.cs
+++ b/src/Bumblebee/Setup/Session.cs
@@ -11,7 +11,7 @@ using OpenQA.Selenium.Support.Extensions;
 
 namespace Bumblebee.Setup
 {
-	public class Session
+	public class Session : IDisposable
 	{
 		private IBlock _currentBlock;
 
@@ -141,9 +141,38 @@ namespace Bumblebee.Setup
 			return this;
 		}
 
+		public virtual void ExecuteJavaScript(string script, params object[] args)
+		{
+			Driver.ExecuteJavaScript<object>(script, args);
+		}
+
 		public virtual T ExecuteJavaScript<T>(string script, params object[] args)
 		{
 			return Driver.ExecuteJavaScript<T>(script, args);
+		}
+
+		~Session()
+		{
+			Dispose(false);
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+
+			GC.SuppressFinalize(this);
+		}
+
+		private void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				// dispose managed resources
+
+				End();
+			}
+
+			// dispose native resources
 		}
 	}
 

--- a/src/Bumblebee/Specifications/ByFunctionWithListOutput.cs
+++ b/src/Bumblebee/Specifications/ByFunctionWithListOutput.cs
@@ -12,7 +12,7 @@ namespace Bumblebee.Specifications
 	{
 		private readonly Func<ISearchContext, IEnumerable<IWebElement>> _function;
 
-		public ByFunctionWithListOutput(Expression<Func<ISearchContext, IEnumerable<IWebElement>>> expression)
+		internal ByFunctionWithListOutput(Expression<Func<ISearchContext, IEnumerable<IWebElement>>> expression)
 		{
 			_function = expression.Compile();
 			Description = String.Format("By.Function: {0}", expression.Body);

--- a/src/Bumblebee/Specifications/ByFunctionWithSingleOutput.cs
+++ b/src/Bumblebee/Specifications/ByFunctionWithSingleOutput.cs
@@ -7,7 +7,7 @@ using OpenQA.Selenium;
 
 namespace Bumblebee.Specifications
 {
-	public class ByFunctionWithSingleOutput : By
+	internal class ByFunctionWithSingleOutput : By
 	{
 		private readonly Func<ISearchContext, IWebElement> _function;
 

--- a/src/Bumblebee/Specifications/ByWithWait.cs
+++ b/src/Bumblebee/Specifications/ByWithWait.cs
@@ -10,7 +10,7 @@ namespace Bumblebee.Specifications
 	/// <summary>
 	/// Wrapper class that accepts a By selector and a timeout period expressed in a TimeSpan.  WHen FindElement or FindElements are called, it uses the WebDriverWait functionality to select.
 	/// </summary>
-	public class ByWithWait : By
+	internal class ByWithWait : By
 	{
 		private readonly By _by;
 		private readonly TimeSpan _timeout;


### PR DESCRIPTION
I have made some of our classes ```internal``` to prevent exposing too much, added ```IDisposable``` to ```Session``` and added a void ```ExecuteJavaScript``` method to prevent awkwardness when trying to execute JavaScript commands (e.g. actions with no return value).