### PR TITLE
Revise EnterText to restore original behaviour.

### DIFF
--- a/src/Bumblebee/Implementation/TextField.cs
+++ b/src/Bumblebee/Implementation/TextField.cs
@@ -23,7 +23,8 @@ namespace Bumblebee.Implementation
 
 		public virtual TCustomResult EnterText<TCustomResult>(string text) where TCustomResult : IBlock
 		{
-			Tag.Clear();
+			var executor = (IJavaScriptExecutor) Session.Driver;
+			executor.ExecuteScript($"arguments[0].value = '';");
 
 			return AppendText<TCustomResult>(text);
 		}

--- a/src/Bumblebee/Implementation/TextField.cs
+++ b/src/Bumblebee/Implementation/TextField.cs
@@ -24,7 +24,7 @@ namespace Bumblebee.Implementation
 		public virtual TCustomResult EnterText<TCustomResult>(string text) where TCustomResult : IBlock
 		{
 			var executor = (IJavaScriptExecutor) Session.Driver;
-			executor.ExecuteScript($"arguments[0].value = '';");
+			executor.ExecuteScript($"arguments[0].value = '';", Tag);
 
 			return AppendText<TCustomResult>(text);
 		}


### PR DESCRIPTION
With the latest versions of the IEDriver, the EnterText() method does not clear the field before entering the desired text for fields that are javascript populated/validated.

This change should restore the original behaviour.

Fixes #110. 
