### PR TITLE
Add Dynamic type to indicate DOM elements that are not always present

### DIFF
--- a/src/Bumblebee.IntegrationTests/Extensions/FindRelatedTests/Given_parent_element_that_gets_removed.cs
+++ b/src/Bumblebee.IntegrationTests/Extensions/FindRelatedTests/Given_parent_element_that_gets_removed.cs
@@ -1,8 +1,8 @@
 ﻿using Bumblebee.Extensions;
+using Bumblebee.IntegrationTests.Shared;
 using Bumblebee.IntegrationTests.Shared.Hosting;
 using Bumblebee.IntegrationTests.Shared.Pages;
 using Bumblebee.Setup;
-using Bumblebee.Setup.DriverEnvironments;
 
 using NUnit.Framework;
 
@@ -17,7 +17,7 @@ namespace Bumblebee.IntegrationTests.Extensions.FindRelatedTests
 		public void TestFixtureSetUp()
 		{
 			Threaded<Session>
-				.With<InternetExplorer>()
+				.With<HeadlessChrome>()
 				.NavigateTo<JavaScriptPopUpPage>(GetUrl("JavaScriptPopUp.html"));
 		}
 

--- a/src/Bumblebee.IntegrationTests/Implementation/ClickableTests/Given_double_clickable.cs
+++ b/src/Bumblebee.IntegrationTests/Implementation/ClickableTests/Given_double_clickable.cs
@@ -8,11 +8,11 @@ using FluentAssertions;
 
 using NUnit.Framework;
 
+// ReSharper disable InconsistentNaming
+
 namespace Bumblebee.IntegrationTests.Implementation.ClickableTests
 {
-	// ReSharper disable InconsistentNaming
-
-	[TestFixture(typeof(HeadlessChrome))]
+	[TestFixture(typeof (HeadlessChrome))]
 	public class Given_double_clickable<T> : HostTestFixture
 		where T : IDriverEnvironment, new()
 	{

--- a/src/Bumblebee.IntegrationTests/Implementation/IEnumerableOfBlocksTests.cs
+++ b/src/Bumblebee.IntegrationTests/Implementation/IEnumerableOfBlocksTests.cs
@@ -10,14 +10,14 @@ using FluentAssertions;
 
 using NUnit.Framework;
 
+// ReSharper disable InconsistentNaming
+
 namespace Bumblebee.IntegrationTests.Implementation
 {
-	// ReSharper disable InconsistentNaming
-
-	[TestFixture(typeof(HeadlessChrome))]
+	[TestFixture(typeof (HeadlessChrome))]
 	public class Given_list_of_complex_blocks<T> : HostTestFixture
-	    where T : IDriverEnvironment, new()
-    {
+		where T : IDriverEnvironment, new()
+	{
 		[SetUp]
 		public void TestSetUp()
 		{

--- a/src/Bumblebee.IntegrationTests/Implementation/NumericFieldTests.cs
+++ b/src/Bumblebee.IntegrationTests/Implementation/NumericFieldTests.cs
@@ -8,10 +8,11 @@ using FluentAssertions;
 
 using NUnit.Framework;
 
+// ReSharper disable InconsistentNaming
+
 namespace Bumblebee.IntegrationTests.Implementation
 {
-	// ReSharper disable InconsistentNaming
-	[TestFixture(typeof(HeadlessChrome))]
+	[TestFixture(typeof (HeadlessChrome))]
 	public class Given_numeric_field<T> : HostTestFixture
 		where T : IDriverEnvironment, new()
 	{

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/DialogPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/DialogPage.cs
@@ -10,34 +10,16 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 		{
 		}
 
-		public IClickable<IAlertDialog> AlertButton
-		{
-			get { return new Clickable<AlertDialog>(this, By.Id("AlertButton")); }
-		}
+		public IClickable<IAlertDialog> AlertButton => new Clickable<AlertDialog>(this, By.Id("AlertButton"));
 
-		public string AlertResult
-		{
-			get { return FindElement(By.Id("AlertResult")).Text; }
-		}
+		public string AlertResult => FindElement(By.Id("AlertResult")).Text;
 
-		public IClickable<IAlertDialog> ConfirmButton
-		{
-			get { return new Clickable<AlertDialog>(this, By.Id("ConfirmButton")); }
-		}
+		public IClickable<IAlertDialog> ConfirmButton => new Clickable<AlertDialog>(this, By.Id("ConfirmButton"));
 
-		public string ConfirmResult
-		{
-			get { return FindElement(By.Id("ConfirmResult")).Text; }
-		}
+		public string ConfirmResult => FindElement(By.Id("ConfirmResult")).Text;
 
-		public IClickable<IAlertDialog> PromptButton
-		{
-			get { return new Clickable<AlertDialog>(this, By.Id("PromptButton")); }
-		}
+		public IClickable<IAlertDialog> PromptButton => new Clickable<AlertDialog>(this, By.Id("PromptButton"));
 
-		public string PromptResult
-		{
-			get { return FindElement(By.Id("PromptResult")).Text; }
-		}
+		public string PromptResult => FindElement(By.Id("PromptResult")).Text;
 	}
 }

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/DoubleClickablePage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/DoubleClickablePage.cs
@@ -16,19 +16,10 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 		{
 		}
 
-		public IDoubleClickable<DoubleClickablePage> ParagraphWithStaticPage
-		{
-			get { return new Clickable<DoubleClickablePage>(this, By.Id("doubleClickable")); }
-		}
+		public IDoubleClickable<DoubleClickablePage> ParagraphWithStaticPage => new Clickable<DoubleClickablePage>(this, By.Id("doubleClickable"));
 
-		public IDoubleClickable ParagraphWithDynamicPage
-		{
-			get { return new Clickable(this, By.Id("doubleClickable")); }
-		}
+		public IDoubleClickable ParagraphWithDynamicPage => new Clickable(this, By.Id("doubleClickable"));
 
-		public string Result
-		{
-			get { return FindElement(By.Id("result")).Text; }
-		}
+		public string Result => FindElement(By.Id("result")).Text;
 	}
 }

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/GenericTablePage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/GenericTablePage.cs
@@ -16,9 +16,6 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 		{
 		}
 
-		public ITable Table
-		{
-			get { return new Table(this, By.Id("DataGrid")); }
-		}
+		public ITable Table => new Table(this, By.Id("DataGrid"));
 	}
 }

--- a/src/Bumblebee.IntegrationTests/Shared/Pages/JavaScriptPopUpPage.cs
+++ b/src/Bumblebee.IntegrationTests/Shared/Pages/JavaScriptPopUpPage.cs
@@ -12,15 +12,9 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 		{
 		}
 
-		public JavaScriptPopUpRegion Region
-		{
-			get { return new JavaScriptPopUpRegion(this, By.Id("TheRegion")); }
-		}
+		public JavaScriptPopUpRegion Region => new JavaScriptPopUpRegion(this, By.Id("TheRegion"));
 
-		public JavaScriptPopUp PopUp
-		{
-			get { return new JavaScriptPopUp(this, By.Id("TheWindow")); }
-		}
+		public Dynamic<JavaScriptPopUp> PopUp => new Dynamic<JavaScriptPopUp>(this, By.Id("TheWindow"));
 	}
 
 	public class JavaScriptPopUpRegion : Block
@@ -29,10 +23,7 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 		{
 		}
 
-		public IClickable<JavaScriptPopUp> OpenPopUp
-		{
-			get { return new Clickable<JavaScriptPopUp>(this, By.Id("TheButton")); }
-		}
+		public IClickable<JavaScriptPopUp> OpenPopUp => new Clickable<JavaScriptPopUp>(this, By.Id("TheButton"));
 	}
 
 	public class JavaScriptPopUp : Block
@@ -41,15 +32,9 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 		{
 		}
 
-		public DataRegion Data
-		{
-			get { return new DataRegion(this, By.ClassName("data-region")); }
-		}
+		public DataRegion Data => new DataRegion(this, By.ClassName("data-region"));
 
-		public IClickable<JavaScriptPopUpRegion> Close
-		{
-			get { return new Clickable<JavaScriptPopUpRegion>(this, By.ClassName("close-button")); }
-		}
+		public IClickable<JavaScriptPopUpRegion> Close => new Clickable<JavaScriptPopUpRegion>(this, By.ClassName("close-button"));
 	}
 
 	public class DataRegion : Block
@@ -58,9 +43,6 @@ namespace Bumblebee.IntegrationTests.Shared.Pages
 		{
 		}
 
-		public string Text
-		{
-			get { return Tag.Text; }
-		}
+		public string Text => Tag.Text;
 	}
 }

--- a/src/Bumblebee/Implementation/Block.cs
+++ b/src/Bumblebee/Implementation/Block.cs
@@ -17,12 +17,12 @@ namespace Bumblebee.Implementation
 		{
 			if (session == null)
 			{
-				throw new ArgumentNullException("session");
+				throw new ArgumentNullException(nameof (session));
 			}
 
 			if (@by == null)
 			{
-				throw new ArgumentNullException("by");
+				throw new ArgumentNullException(nameof (@by));
 			}
 
 			Session = session;
@@ -30,22 +30,19 @@ namespace Bumblebee.Implementation
 
 			InitializeCurrentBlock();
 
-			if (Session.Monkey != null)
-			{
-				Session.Monkey.Invoke(this);
-			}
+			Session.Monkey?.Invoke(this);
 		}
 
 		protected Block(IBlock parent, By @by)
 		{
 			if (parent == null)
 			{
-				throw new ArgumentNullException("parent");
+				throw new ArgumentNullException(nameof (parent));
 			}
 
 			if (@by == null)
 			{
-				throw new ArgumentNullException("by");
+				throw new ArgumentNullException(nameof (@by));
 			}
 
 			Parent = parent;
@@ -54,10 +51,7 @@ namespace Bumblebee.Implementation
 
 			InitializeCurrentBlock();
 
-			if (Session.Monkey != null)
-			{
-				Session.Monkey.Invoke(this);
-			}
+			Session.Monkey?.Invoke(this);
 		}
 
 		/// <summary>
@@ -75,7 +69,7 @@ namespace Bumblebee.Implementation
 		{
 			if (session == null)
 			{
-				throw new ArgumentNullException("session");
+				throw new ArgumentNullException(nameof (session));
 			}
 
 			var type = typeof (TBlock);
@@ -83,7 +77,7 @@ namespace Bumblebee.Implementation
 
 			if (ctor == null)
 			{
-				throw new ArgumentException(String.Format("The specified type ({0}) is not a valid block or page. It must have a constructor that takes only a session.", type));
+				throw new ArgumentException($"The specified type ({type}) is not a valid block or page. It must have a constructor that takes only a session.");
 			}
 
 			var result = (TBlock) ctor.Invoke(new object[] { session });
@@ -104,12 +98,12 @@ namespace Bumblebee.Implementation
 		{
 			if (parent == null)
 			{
-				throw new ArgumentNullException("parent");
+				throw new ArgumentNullException(nameof (parent));
 			}
 
 			if (@by == null)
 			{
-				throw new ArgumentNullException("by");
+				throw new ArgumentNullException(nameof (@by));
 			}
 
 			var type = typeof (TBlock);
@@ -117,7 +111,7 @@ namespace Bumblebee.Implementation
 
 			if (ctor == null)
 			{
-				throw new ArgumentException(String.Format("The specified type ({0}) is not a valid block. It must have a constructor that takes an IBlock parent and a By specification.", type));
+				throw new ArgumentException($"The specified type ({type}) is not a valid block. It must have a constructor that takes an IBlock parent and a By specification.");
 			}
 
 			var result = (TBlock) ctor.Invoke(new object[] { parent, @by });
@@ -125,11 +119,11 @@ namespace Bumblebee.Implementation
 			return result;
 		}
 
-		public IBlock Parent { get; private set; }
+		public IBlock Parent { get; }
 
-		public Session Session { get; private set; }
+		public Session Session { get; }
 
-		public By Specification { get; private set; }
+		public By Specification { get; }
 
 		private void InitializeCurrentBlock()
 		{
@@ -139,10 +133,7 @@ namespace Bumblebee.Implementation
 		/// <summary>
 		/// Gets the Selenium IWebElement that underpins this component.
 		/// </summary>
-		public virtual IWebElement Tag
-		{
-			get { return Parent.FindElement(Specification); }
-		}
+		public virtual IWebElement Tag => Parent.FindElement(Specification);
 
 		/// <summary>
 		/// Gets the value of the specified attribute for this component.

--- a/src/Bumblebee/Implementation/Dynamic.cs
+++ b/src/Bumblebee/Implementation/Dynamic.cs
@@ -1,0 +1,24 @@
+using Bumblebee.Interfaces;
+
+using OpenQA.Selenium;
+
+namespace Bumblebee.Implementation
+{
+	public class Dynamic<TBlock>
+		where TBlock : IBlock
+	{
+		private IBlock Parent { get; }
+		private By Specification { get; }
+
+		public Dynamic(IBlock parent, By @by)
+		{
+			Parent = parent;
+			Specification = @by;
+		}
+
+		internal TBlock Create()
+		{
+			return Block.Create<TBlock>(Parent, Specification);
+		}
+	}
+}

--- a/src/Bumblebee/Implementation/Element.cs
+++ b/src/Bumblebee/Implementation/Element.cs
@@ -18,12 +18,12 @@ namespace Bumblebee.Implementation
 		/// <summary>
 		/// Gets the text for the given element.
 		/// </summary>
-		public virtual string Text { get { return Tag.Text; } }
+		public virtual string Text => Tag.Text;
 
 		/// <summary>
 		/// Gets whether the element is selected or not.
 		/// </summary>
-		public virtual bool Selected { get { return Tag.Selected; } }
+		public virtual bool Selected => Tag.Selected;
 
 		/// <summary>
 		/// The Element requires both a parent block and a specification for finding it.
@@ -71,12 +71,12 @@ namespace Bumblebee.Implementation
 		{
 			if (parent == null)
 			{
-				throw new ArgumentNullException("parent");
+				throw new ArgumentNullException(nameof (parent));
 			}
 
 			if (@by == null)
 			{
-				throw new ArgumentNullException("by");
+				throw new ArgumentNullException(nameof (@by));
 			}
 
 			var type = typeof (TElement);
@@ -90,7 +90,7 @@ namespace Bumblebee.Implementation
 			}
 			else
 			{
-				throw new ArgumentException(String.Format("The specified type ({0}) is not a valid element. It must have a constructor that takes an IBlock parent and a By specification.", type));
+				throw new ArgumentException($"The specified type ({type}) is not a valid element. It must have a constructor that takes an IBlock parent and a By specification.");
 			}
 
 			return result;
@@ -99,25 +99,19 @@ namespace Bumblebee.Implementation
 		/// <summary>
 		/// Gets the parent block.
 		/// </summary>
-		public IBlock Parent { get; private set; }
+		public IBlock Parent { get; }
 
 		/// <summary>
 		/// Gets the current session.
 		/// </summary>
-		public Session Session { get; private set; }
+		public Session Session { get; }
 
-		private By Specification { get; set; }
+		private By Specification { get; }
 
 		/// <summary>
 		/// Gets the Selenium IWebElement that underpins this component.
 		/// </summary>
-		public IWebElement Tag
-		{
-			get
-			{
-				return Parent.FindElement(Specification);
-			}
-		}
+		public IWebElement Tag => Parent.FindElement(Specification);
 
 		/// <summary>
 		/// Gets the value of the specified attribute for this component.

--- a/src/Bumblebee/Implementation/WebDragAndDropPerformer.cs
+++ b/src/Bumblebee/Implementation/WebDragAndDropPerformer.cs
@@ -7,7 +7,7 @@ namespace Bumblebee.Implementation
 {
 	internal class WebDragAndDropPerformer : IPerformsDragAndDrop
 	{
-		public IWebDriver Driver { get; private set; }
+		public IWebDriver Driver { get; }
 
 		public WebDragAndDropPerformer(IWebDriver driver)
 		{


### PR DESCRIPTION
Before this change, dynamic page elements would have to be public properties somewhere in the Page object model so that the framework could find and instantiate them.

We considered a couple of options for fixing this issue:
1. Leave it as is, though this allows for test authors to incorrectly use the dynamic element when it may not be present
2. Allow `IBlock` properties to be defined as `private`, and change the framework to be able to find them as well, though this might make using `private` for what it is intended for difficult
3. Mark these `IBlock`s with an `Attribute`, though this has the same problems as 1.
4. Implement this `Dynamic` type solution, to put something on the page, but not allow test authors access to the `IBlock` itself

Ultimately we chose option 4, because it seemed to be the most intention revealing option.